### PR TITLE
Add VPN info to ETD

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1,5 +1,6 @@
 import os
 from django.core.exceptions import ImproperlyConfigured
+import json
 
 
 def get_env_setting(setting):
@@ -10,6 +11,7 @@ def get_env_setting(setting):
         error_msg = u'Set the %s env variable' % setting
         raise ImproperlyConfigured(error_msg.encode('utf8'))
 
+CAMPUS_IPS = json.loads(get_env_setting('CAMPUS_IPS_JSON'))
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/etd_app/templates/etd_app/candidate.html
+++ b/etd_app/templates/etd_app/candidate.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block content_main %}
-{% if true %}
+{% if True %}
   <div class="alert alert-danger">
     <h3>VPN Required</h3>
     <p>You must be on campus or connected to the Brown VPN to view this page.</p>

--- a/etd_app/templates/etd_app/candidate.html
+++ b/etd_app/templates/etd_app/candidate.html
@@ -38,7 +38,7 @@
         </dd>
     </dl>
     {% if not candidate.thesis.is_locked %}
-      <a class="btn btn-primary" href="{% url 'candidate_metadata' candidate.id %}">Edit (VPN Required)</a>
+      <a class="btn btn-primary" href="{% url 'candidate_metadata' candidate.id %}">Edit</a>
     {% endif %}
   </div>
 

--- a/etd_app/templates/etd_app/candidate.html
+++ b/etd_app/templates/etd_app/candidate.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block content_main %}
-{% if is_campus_ip %}
+{% if not is_campus_ip %}
   <div class="alert alert-danger">
     <h3>VPN Required</h3>
     <p>You must be on campus or connected to the Brown VPN to view this page.</p>

--- a/etd_app/templates/etd_app/candidate.html
+++ b/etd_app/templates/etd_app/candidate.html
@@ -30,7 +30,7 @@
       </dd>
   </dl>
   {% if not candidate.thesis.is_locked %}
-    <a class="btn btn-primary" href="{% url 'candidate_metadata' candidate.id %}">Edit</a>
+    <a class="btn btn-primary" href="{% url 'candidate_metadata' candidate.id %}">Edit (VPN Required)</a>
   {% endif %}
 </div>
 

--- a/etd_app/templates/etd_app/candidate.html
+++ b/etd_app/templates/etd_app/candidate.html
@@ -5,87 +5,96 @@
 {% endblock %}
 
 {% block content_main %}
-<div id="dissertation_info" class="well">
-  <h3>{{ candidate.thesis.label }} Information</h3>
-  <dl class="dl-horizontal">
-    <dt>Title: </dt><dd>{{ candidate.thesis.title|default:'&nbsp;' }}</dd>
-    <dt>Abstract: </dt><dd>{% if candidate.thesis.abstract %}<pre>{{ candidate.thesis.abstract }}</pre>{% else %}&nbsp;{% endif %}</dd>
-    <dt>Topics: </dt>
-      {% if candidate.thesis.keywords.all %}
-        {% for keyword in candidate.thesis.keywords.all %}
-          <dd>{{ keyword }}</dd>
-        {% endfor %}
-      {% else %}
-        <dd>&nbsp;</dd>
-      {% endif %}
-    <dt>Language:</dt><dd>{{ candidate.thesis.language.name }}</dd>
-    <dt>Pagination:</dt>
-      <dd>
-          {% if candidate.thesis.num_prelim_pages %}
-          preliminary pages - {{ candidate.thesis.num_prelim_pages }}<br />
-          {% endif %}
-          {% if candidate.thesis.num_body_pages %}
-          dissertation pages - {{ candidate.thesis.num_body_pages }}
-          {% endif %}
-      </dd>
-  </dl>
-  {% if not candidate.thesis.is_locked %}
-    <a class="btn btn-primary" href="{% url 'candidate_metadata' candidate.id %}">Edit (VPN Required)</a>
-  {% endif %}
-</div>
-
-<div id="dissertation_file" class="well">
-    <h3>{{ candidate.thesis.label }} File</h3>
-    {% if candidate.thesis.original_file_name %}
-        <p>{{ candidate.thesis.original_file_name }}
-        {% if not candidate.thesis.is_locked %}
-          <a class="btn btn-primary" href="{% url 'candidate_upload' candidate.id %}">Replace File</a></p>
+{% if not is_campus_ip %}
+  <div class="alert alert-danger">
+    <h3>VPN Required</h3>
+    <p>You must be on campus or connected to the Brown VPN to view this page.</p>
+    <p><a href="https://ithelp.brown.edu/kb/articles/get-started-with-brown-s-vpn-virtual-private-network">Learn more about the Brown VPN</a></p>
+  </div>
+  <p><a class="btn btn-primary" href="{% url 'candidate_home' candidate.id %}">Return to Candidate Home</a></p>
+{% else %}
+  <div id="dissertation_info" class="well">
+    <h3>{{ candidate.thesis.label }} Information</h3>
+    <dl class="dl-horizontal">
+      <dt>Title: </dt><dd>{{ candidate.thesis.title|default:'&nbsp;' }}</dd>
+      <dt>Abstract: </dt><dd>{% if candidate.thesis.abstract %}<pre>{{ candidate.thesis.abstract }}</pre>{% else %}&nbsp;{% endif %}</dd>
+      <dt>Topics: </dt>
+        {% if candidate.thesis.keywords.all %}
+          {% for keyword in candidate.thesis.keywords.all %}
+            <dd>{{ keyword }}</dd>
+          {% endfor %}
+        {% else %}
+          <dd>&nbsp;</dd>
         {% endif %}
-    {% else %}
-        <p><a class="btn btn-primary" href="{% url 'candidate_upload' candidate.id %}">Upload File</a></p>
+      <dt>Language:</dt><dd>{{ candidate.thesis.language.name }}</dd>
+      <dt>Pagination:</dt>
+        <dd>
+            {% if candidate.thesis.num_prelim_pages %}
+            preliminary pages - {{ candidate.thesis.num_prelim_pages }}<br />
+            {% endif %}
+            {% if candidate.thesis.num_body_pages %}
+            dissertation pages - {{ candidate.thesis.num_body_pages }}
+            {% endif %}
+        </dd>
+    </dl>
+    {% if not candidate.thesis.is_locked %}
+      <a class="btn btn-primary" href="{% url 'candidate_metadata' candidate.id %}">Edit (VPN Required)</a>
     {% endif %}
-</div>
+  </div>
 
-<div id="dissertation_committee" class="well">
-<h3>Committee Members</h3>
-    <div class="table-responsive">
-      <table class="table table-striped table-bordered">
-        <tr>
-          <th>First</th>
-          <th>Last</th>
-          <th>Role</th>
-          <th>Department/Affiliation</th>
-          <th></th>
-        </tr>
-        {% for cmember in candidate.committee_members.all %}
-        <tr>
-          <td>{{cmember.person.first_name}}</td>
-          <td>{{cmember.person.last_name}}</td>
-          <td>{{cmember.get_role_display}}</td>
-          <td>{% if cmember.department %}{{cmember.department.name}}{% else %}{{cmember.affiliation}}{% endif %}</td>
-          <td>
-            {% if not candidate.thesis.is_locked %}
-            <form action="{% url 'candidate_committee_remove' candidate.id cmember.id %}" method="POST">{% csrf_token %}
-              <input class="btn" type="submit" value="Remove" />
-            </form>
-            {% endif %}
-          </td>
-        </tr>
-        {% endfor %}
+  <div id="dissertation_file" class="well">
+      <h3>{{ candidate.thesis.label }} File</h3>
+      {% if candidate.thesis.original_file_name %}
+          <p>{{ candidate.thesis.original_file_name }}
+          {% if not candidate.thesis.is_locked %}
+            <a class="btn btn-primary" href="{% url 'candidate_upload' candidate.id %}">Replace File</a></p>
+          {% endif %}
+      {% else %}
+          <p><a class="btn btn-primary" href="{% url 'candidate_upload' candidate.id %}">Upload File</a></p>
+      {% endif %}
+  </div>
 
-        <tr>
-          <td colspan=5>
-            {% if not candidate.thesis.is_locked %}
-            <a class="btn btn-primary" href="{% url 'candidate_committee' candidate.id %}">
-              <i class="fa fa-plus" aria-hidden="true"></i> Add Committee Member
-            </a>
-            {% endif %}
-          </td>
-        </tr>
-      </table>
-    </div>
-</div>
-{% endblock %}
+  <div id="dissertation_committee" class="well">
+  <h3>Committee Members</h3>
+      <div class="table-responsive">
+        <table class="table table-striped table-bordered">
+          <tr>
+            <th>First</th>
+            <th>Last</th>
+            <th>Role</th>
+            <th>Department/Affiliation</th>
+            <th></th>
+          </tr>
+          {% for cmember in candidate.committee_members.all %}
+          <tr>
+            <td>{{cmember.person.first_name}}</td>
+            <td>{{cmember.person.last_name}}</td>
+            <td>{{cmember.get_role_display}}</td>
+            <td>{% if cmember.department %}{{cmember.department.name}}{% else %}{{cmember.affiliation}}{% endif %}</td>
+            <td>
+              {% if not candidate.thesis.is_locked %}
+              <form action="{% url 'candidate_committee_remove' candidate.id cmember.id %}" method="POST">{% csrf_token %}
+                <input class="btn" type="submit" value="Remove" />
+              </form>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+
+          <tr>
+            <td colspan=5>
+              {% if not candidate.thesis.is_locked %}
+              <a class="btn btn-primary" href="{% url 'candidate_committee' candidate.id %}">
+                <i class="fa fa-plus" aria-hidden="true"></i> Add Committee Member
+              </a>
+              {% endif %}
+            </td>
+          </tr>
+        </table>
+      </div>
+  </div>
+  {% endblock %}
+{% endif %}
 
 {% block content_sidebar %}
 <div class="well">

--- a/etd_app/templates/etd_app/candidate.html
+++ b/etd_app/templates/etd_app/candidate.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block content_main %}
-{% if not is_campus_ip %}
+{% if true %}
   <div class="alert alert-danger">
     <h3>VPN Required</h3>
     <p>You must be on campus or connected to the Brown VPN to view this page.</p>

--- a/etd_app/templates/etd_app/candidate.html
+++ b/etd_app/templates/etd_app/candidate.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block content_main %}
-{% if True %}
+{% if is_campus_ip %}
   <div class="alert alert-danger">
     <h3>VPN Required</h3>
     <p>You must be on campus or connected to the Brown VPN to view this page.</p>

--- a/etd_app/templates/etd_app/candidate.html
+++ b/etd_app/templates/etd_app/candidate.html
@@ -93,8 +93,8 @@
         </table>
       </div>
   </div>
-  {% endblock %}
 {% endif %}
+{% endblock %}
 
 {% block content_sidebar %}
 <div class="well">

--- a/etd_app/templates/etd_app/candidate.html
+++ b/etd_app/templates/etd_app/candidate.html
@@ -9,7 +9,7 @@
   <div class="alert alert-danger">
     <h3>VPN Required</h3>
     <p>You must be on campus or connected to the Brown VPN to view this page.</p>
-    <p><a href="https://ithelp.brown.edu/kb/articles/get-started-with-brown-s-vpn-virtual-private-network">Learn more about the Brown VPN</a></p>
+    <p><a href="https://ithelp.brown.edu/kb/articles/get-started-with-brown-s-vpn-virtual-private-network" target="_blank">Learn more about the Brown VPN</a></p>
   </div>
   <p><a class="btn btn-primary" href="{% url 'candidate_home' candidate.id %}">Return to Candidate Home</a></p>
 {% else %}

--- a/etd_app/templates/etd_app/candidate_metadata.html
+++ b/etd_app/templates/etd_app/candidate_metadata.html
@@ -13,7 +13,7 @@
 
 {% block content_main %}
 <h2>About Your {{ candidate.thesis.label }}</h2>
-<h2> You must be on the VPN for all the features of this form to work properly. See the FAQ page for more information.</h2>
+<h4> You must be on the VPN for all the features of this form to work properly. See the FAQ page for more information.</h4>
     {% crispy form form.helper %}
 {% endblock %}
 

--- a/etd_app/templates/etd_app/candidate_metadata.html
+++ b/etd_app/templates/etd_app/candidate_metadata.html
@@ -13,7 +13,7 @@
 
 {% block content_main %}
 <h2>About Your {{ candidate.thesis.label }}</h2>
-<h3> Note: You must be on the VPN for all the features of this form to work properly. Find more information about using the VPN <a href="https://ithelp.brown.edu/kb/articles/get-started-with-brown-s-vpn-virtual-private-network">here</a></h3>
+<h2> You must be on the VPN for all the features of this form to work properly. See the FAQ page for more information.</h2>
     {% crispy form form.helper %}
 {% endblock %}
 

--- a/etd_app/templates/etd_app/candidate_metadata.html
+++ b/etd_app/templates/etd_app/candidate_metadata.html
@@ -13,6 +13,7 @@
 
 {% block content_main %}
 <h2>About Your {{ candidate.thesis.label }}</h2>
+<h3> Note: You must be on the VPN for all the features of this form to work properly. Find more information about using the VPN <a href="https://ithelp.brown.edu/kb/articles/get-started-with-brown-s-vpn-virtual-private-network">here</a></h3>
     {% crispy form form.helper %}
 {% endblock %}
 

--- a/etd_app/templates/etd_app/faq.html
+++ b/etd_app/templates/etd_app/faq.html
@@ -2,6 +2,10 @@
 {% block static_content %}
 <h2>Frequently Asked Questions</h2>
 
+<h2> Important notice for off-campus use </h2>
+
+<blockquote><p>If you are accessing your account from off campus, you will need to use the VPN in order to access all the features of the site. You can find information about using the VPN <a href="https://ithelp.brown.edu/kb/articles/get-started-with-brown-s-vpn-virtual-private-network">here</a></p>
+
 <h3>Where are Brown’s ETDs available?</h3>
 
 <blockquote><p>Brown ETDs will be available in the <a href="https://repository.library.brown.edu/studio/collections/dissertation/">Brown Digital Repository (BDR)</a>. A permanent URL will be available for use in your resume.</p>

--- a/etd_app/templates/etd_app/faq.html
+++ b/etd_app/templates/etd_app/faq.html
@@ -4,7 +4,7 @@
 
 <h3> Important notice for off-campus use </h3>
 
-<blockquote><p>If you are accessing your account from off campus, you will need to use the VPN in order to access all the features of the site. You can find information about using the VPN <a href="https://ithelp.brown.edu/kb/articles/get-started-with-brown-s-vpn-virtual-private-network">here</a></p></blockquote>
+<blockquote><p>If you are accessing your account from off campus, you will need to use the VPN in order to access all the features of the site. You can find information about using the VPN <a href="https://ithelp.brown.edu/kb/articles/get-started-with-brown-s-vpn-virtual-private-network">here</a>.</p></blockquote>
 
 <h3>Where are Brown’s ETDs available?</h3>
 

--- a/etd_app/templates/etd_app/faq.html
+++ b/etd_app/templates/etd_app/faq.html
@@ -2,13 +2,13 @@
 {% block static_content %}
 <h2>Frequently Asked Questions</h2>
 
-<h2> Important notice for off-campus use </h2>
+<h3> Important notice for off-campus use </h3>
 
 <blockquote><p>If you are accessing your account from off campus, you will need to use the VPN in order to access all the features of the site. You can find information about using the VPN <a href="https://ithelp.brown.edu/kb/articles/get-started-with-brown-s-vpn-virtual-private-network">here</a></p></blockquote>
 
 <h3>Where are Brown’s ETDs available?</h3>
 
-<blockquote><p>Brown ETDs will be available in the <a href="https://repository.library.brown.edu/studio/collections/dissertation/">Brown Digital Repository (BDR)</a>. A permanent URL will be available for use in your resume.</p>
+<blockquote><p>Brown ETDs will be available in the <a href="https://repository.library.brown.edu/studio/collections/dissertation/" target="_blank">Brown Digital Repository (BDR)</a>. A permanent URL will be available for use in your resume.</p>
 
     <p>Dissertations of candidates who elect to enter into an individual publication agreement with ProQuest will also be available in the commercial <a href="http://proquest.umi.com/login?COPT=REJTPUcyODcrNTQyMiszYjEwJklOVD0wJlZFUj0y&clientId=7344">ProQuest Dissertations and Theses Full Text</a> database.</p></blockquote>
 

--- a/etd_app/templates/etd_app/faq.html
+++ b/etd_app/templates/etd_app/faq.html
@@ -4,7 +4,7 @@
 
 <h2> Important notice for off-campus use </h2>
 
-<blockquote><p>If you are accessing your account from off campus, you will need to use the VPN in order to access all the features of the site. You can find information about using the VPN <a href="https://ithelp.brown.edu/kb/articles/get-started-with-brown-s-vpn-virtual-private-network">here</a></p>
+<blockquote><p>If you are accessing your account from off campus, you will need to use the VPN in order to access all the features of the site. You can find information about using the VPN <a href="https://ithelp.brown.edu/kb/articles/get-started-with-brown-s-vpn-virtual-private-network">here</a></p></blockquote>
 
 <h3>Where are Brown’s ETDs available?</h3>
 

--- a/etd_app/utilities.py
+++ b/etd_app/utilities.py
@@ -10,12 +10,12 @@ def is_campus_ip(ip_str: str, campus_ips: List[str]) -> bool:
         ip_str: The IP address to check.
         campus_ips: List of campus IPs. This'll be from settings, but passing in both facilitates testing.
     """
-    ip_obj: ipaddress.IPv4Address = ipaddress.IPv4Address(ip_str)  # in case we need to do CIDR math
-    for campus_ip in campus_ips:
-        if '/' in campus_ip:  # eg CIDR notation, like '192.168.1.0/24'
-            network: ipaddress.IPv4Network = ipaddress.IPv4Network(campus_ip)
-            if ip_obj in network:
-                return True
-        elif ip_str == campus_ip:
-            return True
+    # ip_obj: ipaddress.IPv4Address = ipaddress.IPv4Address(ip_str)  # in case we need to do CIDR math
+    # for campus_ip in campus_ips:
+    #     if '/' in campus_ip:  # eg CIDR notation, like '192.168.1.0/24'
+    #         network: ipaddress.IPv4Network = ipaddress.IPv4Network(campus_ip)
+    #         if ip_obj in network:
+    #             return True
+    #     elif ip_str == campus_ip:
+    #         return True
     return False

--- a/etd_app/utilities.py
+++ b/etd_app/utilities.py
@@ -1,0 +1,21 @@
+import ipaddress
+from typing import List
+
+
+def is_campus_ip(ip_str: str, campus_ips: List[str]) -> bool:
+    """
+    Checks if the IP address is in the list of campus IPs.
+    Supports specific IP addresses, and CIDR notation, like '192.168.1.0/24'.
+    Args:
+        ip_str: The IP address to check.
+        campus_ips: List of campus IPs. This'll be from settings, but passing in both facilitates testing.
+    """
+    ip_obj: ipaddress.IPv4Address = ipaddress.IPv4Address(ip_str)  # in case we need to do CIDR math
+    for campus_ip in campus_ips:
+        if '/' in campus_ip:  # eg CIDR notation, like '192.168.1.0/24'
+            network: ipaddress.IPv4Network = ipaddress.IPv4Network(campus_ip)
+            if ip_obj in network:
+                return True
+        elif ip_str == campus_ip:
+            return True
+    return False

--- a/etd_app/utilities.py
+++ b/etd_app/utilities.py
@@ -10,12 +10,12 @@ def is_campus_ip(ip_str: str, campus_ips: List[str]) -> bool:
         ip_str: The IP address to check.
         campus_ips: List of campus IPs. This'll be from settings, but passing in both facilitates testing.
     """
-    # ip_obj: ipaddress.IPv4Address = ipaddress.IPv4Address(ip_str)  # in case we need to do CIDR math
-    # for campus_ip in campus_ips:
-    #     if '/' in campus_ip:  # eg CIDR notation, like '192.168.1.0/24'
-    #         network: ipaddress.IPv4Network = ipaddress.IPv4Network(campus_ip)
-    #         if ip_obj in network:
-    #             return True
-    #     elif ip_str == campus_ip:
-    #         return True
+    ip_obj: ipaddress.IPv4Address = ipaddress.IPv4Address(ip_str)  # in case we need to do CIDR math
+    for campus_ip in campus_ips:
+        if '/' in campus_ip:  # eg CIDR notation, like '192.168.1.0/24'
+            network: ipaddress.IPv4Network = ipaddress.IPv4Network(campus_ip)
+            if ip_obj in network:
+                return True
+        elif ip_str == campus_ip:
+            return True
     return False

--- a/etd_app/views.py
+++ b/etd_app/views.py
@@ -160,7 +160,7 @@ def candidate_home(request, candidate_id=None):
     other_candidacies = Candidate.objects.filter(person__netid=request.user.username).exclude(id=candidate.id)
     if other_candidacies:
         context_data['other_candidacies'] = other_candidacies
-        context_data['is_campus_ip'] = is_campus_ip(request.META['REMOTE_ADDR'], settings.CAMPUS_IPS), False
+    context_data['is_campus_ip'] = is_campus_ip(request.META['REMOTE_ADDR'], settings.CAMPUS_IPS)
     return render(request, 'etd_app/candidate.html', context_data)
 
 

--- a/etd_app/views.py
+++ b/etd_app/views.py
@@ -13,7 +13,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_http_methods
 from .models import Person, Candidate, Keyword, CommitteeMember
 from .widgets import ID_VAL_SEPARATOR
-
+from .utilities import is_campus_ip
 
 BDR_EMAIL = 'bdr@brown.edu'
 logger = logging.getLogger('etd')
@@ -160,6 +160,7 @@ def candidate_home(request, candidate_id=None):
     other_candidacies = Candidate.objects.filter(person__netid=request.user.username).exclude(id=candidate.id)
     if other_candidacies:
         context_data['other_candidacies'] = other_candidacies
+        context_data['is_campus_ip'] = is_campus_ip(request.META['REMOTE_ADDR'], settings.CAMPUS_IPS), False
     return render(request, 'etd_app/candidate.html', context_data)
 
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     os.environ['SERVER_ROOT'] = 'http://localhost/'
     os.environ['API_URL'] = 'http://localhost/api/'
     os.environ['ALLOWED_HOST'] = 'localhost'
-    os.environ['CAMPUS_IPS_JSON'] = '["0.0.0.0"]'
+    os.environ['CAMPUS_IPS_JSON'] = '["10.0.0.0/8", "128.148.0.0/16", "138.16.0.0/16"]'
     with tempfile.TemporaryDirectory() as tmp:
         os.environ['MEDIA_ROOT'] = os.path.join(tmp, 'media')
         os.environ['LOG_DIR'] = tmp

--- a/run_tests.py
+++ b/run_tests.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     os.environ['SERVER_ROOT'] = 'http://localhost/'
     os.environ['API_URL'] = 'http://localhost/api/'
     os.environ['ALLOWED_HOST'] = 'localhost'
-    os.environ['CAMPUS_IPS_JSON'] = '["10.0.0.0/8", "128.148.0.0/16", "138.16.0.0/16"]'
+    os.environ['CAMPUS_IPS_JSON'] = '[127.0.0.1]'
     with tempfile.TemporaryDirectory() as tmp:
         os.environ['MEDIA_ROOT'] = os.path.join(tmp, 'media')
         os.environ['LOG_DIR'] = tmp

--- a/run_tests.py
+++ b/run_tests.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     os.environ['SERVER_ROOT'] = 'http://localhost/'
     os.environ['API_URL'] = 'http://localhost/api/'
     os.environ['ALLOWED_HOST'] = 'localhost'
-    os.environ['CAMPUS_IPs_JSON'] = '['0.0.0.0']'
+    os.environ['CAMPUS_IPS_JSON'] = '["0.0.0.0"]'
     with tempfile.TemporaryDirectory() as tmp:
         os.environ['MEDIA_ROOT'] = os.path.join(tmp, 'media')
         os.environ['LOG_DIR'] = tmp

--- a/run_tests.py
+++ b/run_tests.py
@@ -21,6 +21,7 @@ if __name__ == '__main__':
     os.environ['SERVER_ROOT'] = 'http://localhost/'
     os.environ['API_URL'] = 'http://localhost/api/'
     os.environ['ALLOWED_HOST'] = 'localhost'
+    os.environ['CAMPUS_IPs_JSON'] = '['0.0.0.0']'
     with tempfile.TemporaryDirectory() as tmp:
         os.environ['MEDIA_ROOT'] = os.path.join(tmp, 'media')
         os.environ['LOG_DIR'] = tmp

--- a/run_tests.py
+++ b/run_tests.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     os.environ['SERVER_ROOT'] = 'http://localhost/'
     os.environ['API_URL'] = 'http://localhost/api/'
     os.environ['ALLOWED_HOST'] = 'localhost'
-    os.environ['CAMPUS_IPS_JSON'] = '[127.0.0.1]'
+    os.environ['CAMPUS_IPS_JSON'] = '["127.0.0.1"]'
     with tempfile.TemporaryDirectory() as tmp:
         os.environ['MEDIA_ROOT'] = os.path.join(tmp, 'media')
         os.environ['LOG_DIR'] = tmp


### PR DESCRIPTION
Due to the cloudflare hosting change, certain features in ETD no longer work unless you are on campus/on the VPN. This PR:
- Adds info about the VPN to the FAQ page and the candidate metadata form (the form where users reported issues)
- Adds a list of campus IPs to the settings (stored in .env)
- Adds a utility function to determine whether a user's IP is in the list of approved IPs
- Changes the view for the candidate metadata form to only allow access if the request IP is in the correct range

Because dev is only accessible on VPN, the dev .env IP range is set to 0.0.0.0 for testing, so it should always not match the request IP and should display a message that you need to use the VPN. 